### PR TITLE
[FEAT] 푼 문제 목록 관련 기능 

### DIFF
--- a/frontend/src/components/ProblemControlDropdown/index.tsx
+++ b/frontend/src/components/ProblemControlDropdown/index.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+
+interface DropdownDisplay {
+  display: boolean;
+}
+
+const DropdownWrapper = styled.button`
+  position: relative;
+  border: none;
+  outline: none;
+  color: black;
+  background-color: white;
+  cursor: pointer;
+  transition: all 0.2s;
+`;
+
+const DropdownSelect = styled.div<DropdownDisplay>`
+  position: absolute;
+  width: 3rem;
+  padding: 0.5rem;
+  border-radius: 20px;
+  border: 1px solid lightGrey;
+  background-color: white;
+  z-index: 999;
+  display: ${(props) => (props.display ? 'block' : 'none')};
+`;
+
+const DropdownOption = styled.div`
+  padding: 0.5rem;
+  color: ${(props) => props.color ?? 'black'};
+`;
+
+const ProblemControlDropdown = ({ displayText }: { displayText: string }) => {
+  const [dropdownDisplay, setDropdownDisplay] = useState(false);
+
+  const toggleDropdownDisplay = () => setDropdownDisplay(() => !dropdownDisplay);
+
+  return (
+    <DropdownWrapper type="button" onClick={toggleDropdownDisplay}>
+      {displayText}
+      <DropdownSelect display={dropdownDisplay}>
+        <DropdownOption>수정</DropdownOption>
+        <DropdownOption color="red">삭제</DropdownOption>
+      </DropdownSelect>
+    </DropdownWrapper>
+  );
+};
+
+export default ProblemControlDropdown;

--- a/frontend/src/components/ProblemControlDropdown/index.tsx
+++ b/frontend/src/components/ProblemControlDropdown/index.tsx
@@ -1,47 +1,52 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 interface DropdownDisplay {
-  display: boolean;
+  isDisplayed: boolean;
 }
 
-const DropdownWrapper = styled.button`
+const DropdownWrapper = styled.div`
   position: relative;
-  border: none;
-  outline: none;
-  color: black;
-  background-color: white;
   cursor: pointer;
   transition: all 0.2s;
 `;
 
 const DropdownSelect = styled.div<DropdownDisplay>`
   position: absolute;
-  width: 3rem;
-  padding: 0.5rem;
-  border-radius: 20px;
-  border: 1px solid lightGrey;
-  background-color: white;
   z-index: 999;
-  display: ${(props) => (props.display ? 'block' : 'none')};
+  display: ${(props) => (props.isDisplayed ? 'block' : 'none')};
 `;
 
-const DropdownOption = styled.div`
+const DropdownOption = styled.button`
+  width: 3.5rem;
   padding: 0.5rem;
+  border: 1px solid lightGrey;
+  background-color: white;
   color: ${(props) => props.color ?? 'black'};
 `;
 
 const ProblemControlDropdown = ({ displayText }: { displayText: string }) => {
-  const [dropdownDisplay, setDropdownDisplay] = useState(false);
+  const [isDisplayed, setIsDisplayed] = useState(false);
 
-  const toggleDropdownDisplay = () => setDropdownDisplay(() => !dropdownDisplay);
+  const toggleDropdownDisplay = () => setIsDisplayed(() => !isDisplayed);
+
+  const testHandleDropdownOption = (e: React.MouseEvent<HTMLDivElement>) => {
+    const clickedOption = e.target as HTMLButtonElement;
+    if (clickedOption.value === 'edit') {
+      window.alert('푼 문제 정보를 수정하는 Modal 이 뜹니다.');
+    } else {
+      window.alert('푼 문제 정보 삭제를 확인하는 Modal 이 뜹니다.');
+    }
+  };
 
   return (
-    <DropdownWrapper type="button" onClick={toggleDropdownDisplay}>
+    <DropdownWrapper onClick={toggleDropdownDisplay}>
       {displayText}
-      <DropdownSelect display={dropdownDisplay}>
-        <DropdownOption>수정</DropdownOption>
-        <DropdownOption color="red">삭제</DropdownOption>
+      <DropdownSelect isDisplayed={isDisplayed} onClick={testHandleDropdownOption}>
+        <DropdownOption value="edit">수정</DropdownOption>
+        <DropdownOption value="delete" color="red">
+          삭제
+        </DropdownOption>
       </DropdownSelect>
     </DropdownWrapper>
   );

--- a/frontend/src/components/ProblemList/index.tsx
+++ b/frontend/src/components/ProblemList/index.tsx
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, useQuery } from 'react-query';
+import { QueryFunctionContext, useMutation, useQuery, useQueryClient } from 'react-query';
 import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { AiOutlinePlus } from 'react-icons/ai';
@@ -63,18 +63,47 @@ const fetchSolvedProblemList = async ({ queryKey }: QueryFunctionContext) => {
   }
 };
 
+const fetchNewProblem = async (problemDetails: SolvedProblem) => {
+  const addResult = fetch('/api/problems', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(problemDetails),
+  });
+  return addResult;
+};
+
 const ProblemList = () => {
   const [searchParams] = useSearchParams();
   const userId = searchParams.get('id');
+  const queryClient = useQueryClient();
+
   const NO_SOLVED_PROBLEMS = '푼 문제가 없습니다? 🤨';
 
   const { data: solvedProblem } = useQuery<SolvedProblem[]>(['solvedProblem', userId], fetchSolvedProblemList);
+
+  const newProblemMutation = useMutation(fetchNewProblem, {
+    onSuccess: () => queryClient.invalidateQueries(['solvedProblem', userId]),
+  });
+
+  const testAddNewProblem = () => {
+    newProblemMutation.mutate({
+      userId: 'iyu88',
+      platform: '백준',
+      level: '실버',
+      date: '2023/01/15',
+      image: 'https://picsum.photos/200',
+      link: 'https://www.acmicpc.net/problem/1234',
+      id: '1',
+    });
+  };
 
   return (
     <UserCommonContainer>
       <ProblemListTitle>
         <h2>푼 문제 목록</h2>
-        <NewProblemButton>
+        <NewProblemButton type="button" onClick={testAddNewProblem}>
           <AiOutlinePlus size="20" color="white" />
         </NewProblemButton>
       </ProblemListTitle>

--- a/frontend/src/components/ProblemList/index.tsx
+++ b/frontend/src/components/ProblemList/index.tsx
@@ -1,3 +1,5 @@
+import { QueryFunctionContext, useQuery } from 'react-query';
+import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { AiOutlinePlus } from 'react-icons/ai';
 import UserCommonContainer from '../UserCommonContainer';
@@ -42,7 +44,32 @@ const ProblemAttribute = styled.th`
   text-align: center;
 `;
 
+interface SolvedProblem {
+  platform: string;
+  level: string;
+  link: string;
+  image: string;
+  date: string;
+  userId: string;
+}
+
+const fetchSolvedProblemList = async ({ queryKey }: QueryFunctionContext) => {
+  const userId = queryKey[1];
+  try {
+    const response = await fetch(`/api/problems${userId && `?user=${userId}`}`);
+    const solvedProblemListJSON = await response.json();
+    return solvedProblemListJSON;
+  } catch (err) {
+    throw new Error('푼 문제 정보를 불러오는 데 오류가 발생했습니다.');
+  }
+};
+
 const ProblemList = () => {
+  const [searchParams] = useSearchParams();
+  const userId = searchParams.get('id');
+
+  const { data: solvedProblem } = useQuery<SolvedProblem[]>(['solvedProblem', userId], fetchSolvedProblemList);
+
   return (
     <UserCommonContainer>
       <ProblemListTitle>
@@ -53,12 +80,14 @@ const ProblemList = () => {
       </ProblemListTitle>
       <ProblemListWrapper cellSpacing="0">
         <ProblemListHeader>
-          <ProblemAttribute>플랫폼</ProblemAttribute>
-          <ProblemAttribute>난이도</ProblemAttribute>
-          <ProblemAttribute>문제 링크</ProblemAttribute>
-          <ProblemAttribute>증빙</ProblemAttribute>
-          <ProblemAttribute>날짜</ProblemAttribute>
-          <ProblemAttribute>{null}</ProblemAttribute>
+          <tr>
+            <ProblemAttribute>플랫폼</ProblemAttribute>
+            <ProblemAttribute>난이도</ProblemAttribute>
+            <ProblemAttribute>문제 링크</ProblemAttribute>
+            <ProblemAttribute>증빙</ProblemAttribute>
+            <ProblemAttribute>날짜</ProblemAttribute>
+            <ProblemAttribute>{null}</ProblemAttribute>
+          </tr>
         </ProblemListHeader>
         <tbody />
       </ProblemListWrapper>
@@ -66,4 +95,5 @@ const ProblemList = () => {
   );
 };
 
+//
 export default ProblemList;

--- a/frontend/src/components/ProblemList/index.tsx
+++ b/frontend/src/components/ProblemList/index.tsx
@@ -1,0 +1,13 @@
+import UserCommonContainer from '../UserCommonContainer';
+import ProblemListItem from '../ProblemListItem';
+
+const ProblemList = () => {
+  return (
+    <UserCommonContainer>
+      <h1>문제 리스트 목록</h1>
+      <ProblemListItem />
+    </UserCommonContainer>
+  );
+};
+
+export default ProblemList;

--- a/frontend/src/components/ProblemList/index.tsx
+++ b/frontend/src/components/ProblemList/index.tsx
@@ -1,11 +1,67 @@
+import styled from 'styled-components';
+import { AiOutlinePlus } from 'react-icons/ai';
 import UserCommonContainer from '../UserCommonContainer';
-import ProblemListItem from '../ProblemListItem';
+
+const ProblemListWrapper = styled.table`
+  width: 100%;
+`;
+
+const ProblemListTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const NewProblemButton = styled.button`
+  display: flex;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  outline: none;
+  border: none;
+  border-radius: 10px;
+  background-color: black;
+  cursor: pointer;
+`;
+
+const ProblemListHeader = styled.thead`
+  background-color: lightGrey;
+  th:first-of-type {
+    border-top-left-radius: 10px;
+    padding-left: 1rem;
+  }
+
+  th:last-of-type {
+    border-top-right-radius: 10px;
+    padding-right: 1rem;
+  }
+`;
+
+const ProblemAttribute = styled.th`
+  padding: 0.75rem 0;
+  text-align: center;
+`;
 
 const ProblemList = () => {
   return (
     <UserCommonContainer>
-      <h1>문제 리스트 목록</h1>
-      <ProblemListItem />
+      <ProblemListTitle>
+        <h2>푼 문제 목록</h2>
+        <NewProblemButton>
+          <AiOutlinePlus size="20" color="white" />
+        </NewProblemButton>
+      </ProblemListTitle>
+      <ProblemListWrapper cellSpacing="0">
+        <ProblemListHeader>
+          <ProblemAttribute>플랫폼</ProblemAttribute>
+          <ProblemAttribute>난이도</ProblemAttribute>
+          <ProblemAttribute>문제 링크</ProblemAttribute>
+          <ProblemAttribute>증빙</ProblemAttribute>
+          <ProblemAttribute>날짜</ProblemAttribute>
+          <ProblemAttribute>{null}</ProblemAttribute>
+        </ProblemListHeader>
+        <tbody />
+      </ProblemListWrapper>
     </UserCommonContainer>
   );
 };

--- a/frontend/src/components/ProblemList/index.tsx
+++ b/frontend/src/components/ProblemList/index.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { AiOutlinePlus } from 'react-icons/ai';
 import UserCommonContainer from '../UserCommonContainer';
+import ProblemListItem from '../ProblemListItem';
 
 const ProblemListWrapper = styled.table`
   width: 100%;
@@ -45,6 +46,7 @@ const ProblemAttribute = styled.th`
 `;
 
 interface SolvedProblem {
+  id: string;
   platform: string;
   level: string;
   link: string;
@@ -89,7 +91,24 @@ const ProblemList = () => {
             <ProblemAttribute>{null}</ProblemAttribute>
           </tr>
         </ProblemListHeader>
-        <tbody />
+        <tbody>
+          {solvedProblem?.length ? (
+            solvedProblem.map((p) => (
+              <ProblemListItem
+                key={p.id}
+                platform={p.platform}
+                level={p.level}
+                link={p.link}
+                image={p.image}
+                date={p.date}
+              />
+            ))
+          ) : (
+            <tr>
+              <td>푼 문제가 없습니다.</td>
+            </tr>
+          )}
+        </tbody>
       </ProblemListWrapper>
     </UserCommonContainer>
   );

--- a/frontend/src/components/ProblemList/index.tsx
+++ b/frontend/src/components/ProblemList/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { AiOutlinePlus } from 'react-icons/ai';
 import UserCommonContainer from '../UserCommonContainer';
 import ProblemListItem from '../ProblemListItem';
+import SolvedProblem from '../../types/solvedProblem';
 
 const ProblemListWrapper = styled.table`
   width: 100%;
@@ -44,16 +45,6 @@ const ProblemAttribute = styled.th`
   padding: 0.75rem 0;
   text-align: center;
 `;
-
-interface SolvedProblem {
-  id: string;
-  platform: string;
-  level: string;
-  link: string;
-  image: string;
-  date: string;
-  userId: string;
-}
 
 const fetchSolvedProblemList = async ({ queryKey }: QueryFunctionContext) => {
   const userId = queryKey[1];

--- a/frontend/src/components/ProblemList/index.tsx
+++ b/frontend/src/components/ProblemList/index.tsx
@@ -41,9 +41,15 @@ const ProblemListHeader = styled.thead`
   }
 `;
 
-const ProblemAttribute = styled.th`
+const ProblemTableHeader = styled.th`
   padding: 0.75rem 0;
   text-align: center;
+`;
+
+const ProblemTableCell = styled.td`
+  padding: 0.75rem 0;
+  text-align: center;
+  border-bottom: 1px solid black;
 `;
 
 const fetchSolvedProblemList = async ({ queryKey }: QueryFunctionContext) => {
@@ -60,6 +66,7 @@ const fetchSolvedProblemList = async ({ queryKey }: QueryFunctionContext) => {
 const ProblemList = () => {
   const [searchParams] = useSearchParams();
   const userId = searchParams.get('id');
+  const NO_SOLVED_PROBLEMS = '푼 문제가 없습니다? 🤨';
 
   const { data: solvedProblem } = useQuery<SolvedProblem[]>(['solvedProblem', userId], fetchSolvedProblemList);
 
@@ -74,12 +81,12 @@ const ProblemList = () => {
       <ProblemListWrapper cellSpacing="0">
         <ProblemListHeader>
           <tr>
-            <ProblemAttribute>플랫폼</ProblemAttribute>
-            <ProblemAttribute>난이도</ProblemAttribute>
-            <ProblemAttribute>문제 링크</ProblemAttribute>
-            <ProblemAttribute>증빙</ProblemAttribute>
-            <ProblemAttribute>날짜</ProblemAttribute>
-            <ProblemAttribute>{null}</ProblemAttribute>
+            <ProblemTableHeader>플랫폼</ProblemTableHeader>
+            <ProblemTableHeader>난이도</ProblemTableHeader>
+            <ProblemTableHeader>문제 링크</ProblemTableHeader>
+            <ProblemTableHeader>증빙</ProblemTableHeader>
+            <ProblemTableHeader>날짜</ProblemTableHeader>
+            <ProblemTableHeader>{null}</ProblemTableHeader>
           </tr>
         </ProblemListHeader>
         <tbody>
@@ -96,7 +103,7 @@ const ProblemList = () => {
             ))
           ) : (
             <tr>
-              <td>푼 문제가 없습니다.</td>
+              <ProblemTableCell colSpan={6}>{NO_SOLVED_PROBLEMS}</ProblemTableCell>
             </tr>
           )}
         </tbody>
@@ -105,5 +112,4 @@ const ProblemList = () => {
   );
 };
 
-//
 export default ProblemList;

--- a/frontend/src/components/ProblemListItem/index.tsx
+++ b/frontend/src/components/ProblemListItem/index.tsx
@@ -33,13 +33,19 @@ const ProblemImageButton = styled(ProblemCommonButton)`
 `;
 
 const ProblemListItem = ({ platform, level, link, image, date }: SolvedProblem) => {
+  const testOpenProofImageModal = () => {
+    window.alert(`다음 이미지를 표시하는 Modal 이 뜹니다. ${image}`);
+  };
+
   return (
     <ProblemItemWrapper>
       <ProblemAttribute>{platform}</ProblemAttribute>
       <ProblemAttribute>{level}</ProblemAttribute>
       <ProblemAttribute>{link}</ProblemAttribute>
       <ProblemAttribute>
-        <ProblemImageButton type="button">사진 보기</ProblemImageButton>
+        <ProblemImageButton type="button" onClick={testOpenProofImageModal}>
+          사진 보기
+        </ProblemImageButton>
       </ProblemAttribute>
       <ProblemAttribute>{date}</ProblemAttribute>
       <ProblemAttribute>

--- a/frontend/src/components/ProblemListItem/index.tsx
+++ b/frontend/src/components/ProblemListItem/index.tsx
@@ -1,17 +1,50 @@
+import styled from 'styled-components';
 import SolvedProblem from '../../types/solvedProblem';
+
+const ProblemItemWrapper = styled.tr`
+  td:first-of-type {
+    padding-left: 1rem;
+  }
+
+  td:last-of-type {
+    padding-right: 1rem;
+  }
+`;
+
+const ProblemAttribute = styled.td`
+  padding: 0.75rem 0;
+  text-align: center;
+  border-bottom: 1px solid black;
+`;
+
+const ProblemCommonButton = styled.button`
+  background-color: white;
+  border: none;
+  outline: none;
+  cursor: pointer;
+`;
+
+const ProblemImageButton = styled(ProblemCommonButton)`
+  padding: 0.375rem 1rem;
+  border-radius: 10px;
+  color: white;
+  background-color: #745aa8;
+`;
 
 const ProblemListItem = ({ platform, level, link, image, date }: SolvedProblem) => {
   return (
-    <tr>
-      <td>{platform}</td>
-      <td>{level}</td>
-      <td>{link}</td>
-      <td>
-        <button type="button">사진 보기</button>
-      </td>
-      <td>{date}</td>
-      <td>···</td>
-    </tr>
+    <ProblemItemWrapper>
+      <ProblemAttribute>{platform}</ProblemAttribute>
+      <ProblemAttribute>{level}</ProblemAttribute>
+      <ProblemAttribute>{link}</ProblemAttribute>
+      <ProblemAttribute>
+        <ProblemImageButton type="button">사진 보기</ProblemImageButton>
+      </ProblemAttribute>
+      <ProblemAttribute>{date}</ProblemAttribute>
+      <ProblemAttribute>
+        <ProblemCommonButton type="button">···</ProblemCommonButton>
+      </ProblemAttribute>
+    </ProblemItemWrapper>
   );
 };
 

--- a/frontend/src/components/ProblemListItem/index.tsx
+++ b/frontend/src/components/ProblemListItem/index.tsx
@@ -1,5 +1,24 @@
-const ProblemListItem = () => {
-  return <p>문제 리스트 아이템</p>;
+interface SolvedProblem {
+  platform: string;
+  level: string;
+  link: string;
+  image: string;
+  date: string;
+}
+
+const ProblemListItem = ({ platform, level, link, image, date }: SolvedProblem) => {
+  return (
+    <tr>
+      <td>{platform}</td>
+      <td>{level}</td>
+      <td>{link}</td>
+      <td>
+        <button type="button">사진 보기</button>
+      </td>
+      <td>{date}</td>
+      <td>···</td>
+    </tr>
+  );
 };
 
 export default ProblemListItem;

--- a/frontend/src/components/ProblemListItem/index.tsx
+++ b/frontend/src/components/ProblemListItem/index.tsx
@@ -1,10 +1,4 @@
-interface SolvedProblem {
-  platform: string;
-  level: string;
-  link: string;
-  image: string;
-  date: string;
-}
+import SolvedProblem from '../../types/solvedProblem';
 
 const ProblemListItem = ({ platform, level, link, image, date }: SolvedProblem) => {
   return (

--- a/frontend/src/components/ProblemListItem/index.tsx
+++ b/frontend/src/components/ProblemListItem/index.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import SolvedProblem from '../../types/solvedProblem';
+import ProblemControlDropdown from '../ProblemControlDropdown';
 
 const ProblemItemWrapper = styled.tr`
   td:first-of-type {
@@ -42,7 +43,7 @@ const ProblemListItem = ({ platform, level, link, image, date }: SolvedProblem) 
       </ProblemAttribute>
       <ProblemAttribute>{date}</ProblemAttribute>
       <ProblemAttribute>
-        <ProblemCommonButton type="button">···</ProblemCommonButton>
+        <ProblemControlDropdown displayText="···" />
       </ProblemAttribute>
     </ProblemItemWrapper>
   );

--- a/frontend/src/components/ProblemListItem/index.tsx
+++ b/frontend/src/components/ProblemListItem/index.tsx
@@ -1,0 +1,5 @@
+const ProblemListItem = () => {
+  return <p>문제 리스트 아이템</p>;
+};
+
+export default ProblemListItem;

--- a/frontend/src/components/UserCommonContainer/index.tsx
+++ b/frontend/src/components/UserCommonContainer/index.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const UserCommonContainer = styled.section`
+  padding: 2rem;
+  border-radius: 20px;
+  background-color: white;
+`;
+
+export default UserCommonContainer;

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,6 +1,7 @@
 import rankingApi from './ranking';
 import userProfileApi from './userProfile';
+import solvedProblemApi from './solvedProblem';
 
-const handlers = [...rankingApi, ...userProfileApi];
+const handlers = [...rankingApi, ...userProfileApi, ...solvedProblemApi];
 
 export default handlers;

--- a/frontend/src/mocks/handlers/solvedProblem.ts
+++ b/frontend/src/mocks/handlers/solvedProblem.ts
@@ -1,6 +1,7 @@
 import { rest } from 'msw';
+import SolvedProblem from '../../types/solvedProblem';
 
-const mockSolvedProblem = [
+const mockSolvedProblem: SolvedProblem[] = [
   {
     id: '1',
     userId: 'iyu88',
@@ -74,6 +75,11 @@ const solvedProblemApi = [
       return res(ctx.status(200), ctx.json(userSolvedProblem));
     }
     return res(ctx.status(200), ctx.json(mockSolvedProblem));
+  }),
+  rest.post('/api/problems', async (req, res, ctx) => {
+    const problemDeatils = await req.json();
+    mockSolvedProblem.push(problemDeatils);
+    return res(ctx.status(200), ctx.json({ message: '성공적으로 추가되었습니다.' }));
   }),
 ];
 

--- a/frontend/src/mocks/handlers/solvedProblem.ts
+++ b/frontend/src/mocks/handlers/solvedProblem.ts
@@ -1,0 +1,73 @@
+import { rest } from 'msw';
+
+const mockSolvedProblem = [
+  {
+    userId: 'iyu88',
+    platform: '백준',
+    level: '다이아몬드',
+    link: 'https://www.acmicpc.net/problem/1655',
+    image: 'https://picsum.photos/200',
+    date: '2023/01/10',
+  },
+  {
+    userId: 'iyu88',
+    platform: '프로그래머스',
+    level: 'level 3',
+    link: 'https://school.programmers.co.kr/learn...',
+    image: 'https://picsum.photos/200',
+    date: '2023/01/10',
+  },
+  {
+    userId: 'iyu88',
+    platform: '해커랭크',
+    level: 'Medium',
+    link: 'https://www.hackerrank.com/challenge...',
+    image: 'https://picsum.photos/200',
+    date: '2023/01/10',
+  },
+  {
+    userId: 'iyu88',
+    platform: '해커랭크',
+    level: 'Medium',
+    link: 'https://www.hackerrank.com/challenge...',
+    image: 'https://picsum.photos/200',
+    date: '2023/01/10',
+  },
+  {
+    userId: 'caseBread',
+    platform: '프로그래머스',
+    level: 'level 3',
+    link: 'https://school.programmers.co.kr/learn...',
+    image: 'https://picsum.photos/200',
+    date: '2023/01/10',
+  },
+  {
+    userId: 'caseBread',
+    platform: '해커랭크',
+    level: 'Medium',
+    link: 'https://www.hackerrank.com/challenge...',
+    image: 'https://picsum.photos/200',
+    date: '2023/01/10',
+  },
+  {
+    userId: 'caseBread',
+    platform: '해커랭크',
+    level: 'Medium',
+    link: 'https://www.hackerrank.com/challenge...',
+    image: 'https://picsum.photos/200',
+    date: '2023/01/10',
+  },
+];
+
+const solvedProblemApi = [
+  rest.get('/api/problems', (req, res, ctx) => {
+    const userId = req.url.searchParams.get('user');
+    if (userId) {
+      const userSolvedProblem = Object.values(mockSolvedProblem).filter((p) => p.userId === userId);
+      return res(ctx.status(200), ctx.json(userSolvedProblem));
+    }
+    return res(ctx.status(200), ctx.json(mockSolvedProblem));
+  }),
+];
+
+export default solvedProblemApi;

--- a/frontend/src/mocks/handlers/solvedProblem.ts
+++ b/frontend/src/mocks/handlers/solvedProblem.ts
@@ -2,6 +2,7 @@ import { rest } from 'msw';
 
 const mockSolvedProblem = [
   {
+    id: '1',
     userId: 'iyu88',
     platform: '백준',
     level: '다이아몬드',
@@ -10,6 +11,7 @@ const mockSolvedProblem = [
     date: '2023/01/10',
   },
   {
+    id: '2',
     userId: 'iyu88',
     platform: '프로그래머스',
     level: 'level 3',
@@ -18,6 +20,7 @@ const mockSolvedProblem = [
     date: '2023/01/10',
   },
   {
+    id: '3',
     userId: 'iyu88',
     platform: '해커랭크',
     level: 'Medium',
@@ -26,6 +29,7 @@ const mockSolvedProblem = [
     date: '2023/01/10',
   },
   {
+    id: '4',
     userId: 'iyu88',
     platform: '해커랭크',
     level: 'Medium',
@@ -34,6 +38,7 @@ const mockSolvedProblem = [
     date: '2023/01/10',
   },
   {
+    id: '5',
     userId: 'caseBread',
     platform: '프로그래머스',
     level: 'level 3',
@@ -42,6 +47,7 @@ const mockSolvedProblem = [
     date: '2023/01/10',
   },
   {
+    id: '6',
     userId: 'caseBread',
     platform: '해커랭크',
     level: 'Medium',
@@ -50,6 +56,7 @@ const mockSolvedProblem = [
     date: '2023/01/10',
   },
   {
+    id: '7',
     userId: 'caseBread',
     platform: '해커랭크',
     level: 'Medium',

--- a/frontend/src/pages/UserHome.tsx
+++ b/frontend/src/pages/UserHome.tsx
@@ -1,20 +1,26 @@
 import styled from 'styled-components';
 import UserInfoContainer from '../components/UserInfoContainer';
+import UserCommonContainer from '../components/UserCommonContainer';
 
 const UserHomeWrapper = styled.div`
   display: flex;
   justify-content: space-between;
+  gap: 1.375rem;
 `;
 
-const UserCommonContainer = styled.div`
+const UserHistoryWrapper = styled.div`
   flex: 3;
+  display: flex;
+  flex-direction: column;
 `;
 
 const UserHome = () => {
   return (
     <UserHomeWrapper>
       <UserInfoContainer />
-      <UserCommonContainer />
+      <UserHistoryWrapper>
+        <UserCommonContainer />
+      </UserHistoryWrapper>
     </UserHomeWrapper>
   );
 };

--- a/frontend/src/pages/UserHome.tsx
+++ b/frontend/src/pages/UserHome.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import UserInfoContainer from '../components/UserInfoContainer';
-import UserCommonContainer from '../components/UserCommonContainer';
+import ProblemList from '../components/ProblemList';
 
 const UserHomeWrapper = styled.div`
   display: flex;
@@ -19,7 +19,7 @@ const UserHome = () => {
     <UserHomeWrapper>
       <UserInfoContainer />
       <UserHistoryWrapper>
-        <UserCommonContainer />
+        <ProblemList />
       </UserHistoryWrapper>
     </UserHomeWrapper>
   );

--- a/frontend/src/types/solvedProblem.d.ts
+++ b/frontend/src/types/solvedProblem.d.ts
@@ -1,0 +1,11 @@
+declare type SolvedProblem = {
+  id?: string;
+  userId?: string;
+  platform: string;
+  level: string;
+  link: string;
+  image: string;
+  date: string;
+};
+
+export default SolvedProblem;

--- a/frontend/src/types/solvedProblem.d.ts
+++ b/frontend/src/types/solvedProblem.d.ts
@@ -1,11 +1,11 @@
 declare type SolvedProblem = {
   id?: string;
   userId?: string;
+  date?: string;
   platform: string;
   level: string;
   link: string;
   image: string;
-  date: string;
 };
 
 export default SolvedProblem;


### PR DESCRIPTION
<!-- 이 PR에서 구현한 작업들을 나열 -->

## 주요 작업사항

-  #16 
- #17 
  - 내부에서 useQuery 로 데이터 목록을 호출합니다. 
    - Mock API 가 작성되어 있습니다. 
  - useMutation 으로 새로운 푼 문제를 등록합니다. 
    - Modal 창을 생성한 뒤, 확인 버튼을 눌러서 등록해야 하지만, 일단 테스트를 위해서 버튼을 누르면 더미 데이터가 추가됩니다. 
    - Mock API 가 작성되어 있습니다.  
  - ProblemListItem 컴포넌트 구현  
- #18 
   - 수정 / 삭제 버튼이 표시되는 UI 를 만들었습니다. 
   - Mock API 가 작성되어 있지 않습니다. 
     ( ProblemId 를 전체적으로 Mock 데이터나 데이터 타입에 명시해야 할 것 같습니다. 이걸 아직 안해서 작성 안했습니다. )

<!-- (선택) 작업사항을 파악하기 쉽게 스크린샷 첨부 -->

## 스크린샷

### Dropdown UI 
<img width="492" alt="스크린샷 2023-01-15 17 18 15" src="https://user-images.githubusercontent.com/31645195/212529992-b42d450c-9fcb-44f9-9e58-39df2d01b06e.png">

### 문제 추가했을 때 리렌더링
![화면-기록-2023-01-15-17 12 38](https://user-images.githubusercontent.com/31645195/212530027-c80ae59e-f9e9-45a1-8a78-42df66d5726a.gif)

<!-- (선택) 리뷰요청사항 및 기타 하고싶은말 -->

## 팀원분들께
- 작성하면서 Modal 사용처를 정리해보았습니다. 
  - 푼 문제 새로 생성할 때 
  - 증빙 사진 보기 버튼을 눌렀을 때 
  - 삭제 요청을 다시 한 번 확인할 때 

- 변수명 위주로 봐주세요! 
  - 생각하면서 짰는데, 역시 너무 어려운 것 같습니다. 
  - 스타일 컴포넌트 이름에 반복적인 부분이 많이 들어가는데, 이런 부분을 어떻게 처리하면 좋을지 의견주세요!!! ( 아래에 예시 사진이 있습니다. )
  - 물론 tailwind 쓰게 되면 문제 없겠지만, 이런 상황에서 보통 어떻게  하시는지 노하우가 있을까요? 
    ![스크린샷 2023-01-15 17 21 40](https://user-images.githubusercontent.com/31645195/212530127-6622e505-2a56-484a-bf07-fd28b46e1a6e.png)

- <del>작업하다보니까 PR 이 조금 커진 것 같습니다. 다음부터는 나누도록 노력할게요! 😅</del> 막상 올리니까 얼마 안되긴 하네요? ㅎㅎ