### PR TITLE
[FEAT] 푼 문제 생성, 목록, 삭제

### DIFF
--- a/backend/ormconfig.ts
+++ b/backend/ormconfig.ts
@@ -1,9 +1,11 @@
 import dotenv from 'dotenv';
-import { DataSource } from 'typeorm';
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { SeederOptions } from 'typeorm-extension';
+import PlatformLevelSeeder from './src/seeds/platformLevel.seeder';
 
 dotenv.config();
 
-export const db = new DataSource({
+const options: DataSourceOptions & SeederOptions = {
   type: 'mysql',
   host: process.env.DB_HOST,
   port: Number(process.env.DB_PORT),
@@ -13,4 +15,7 @@ export const db = new DataSource({
   synchronize: true,
   logging: true,
   entities: ['src/entities/*.ts'],
-});
+  seeds: [PlatformLevelSeeder],
+};
+
+export const db = new DataSource(options);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.2.2",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.0",
         "dotenv": "^16.0.3",
         "express-session": "^1.17.3",
         "morgan": "^1.10.0",
@@ -197,6 +199,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
+      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -516,6 +523,21 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
+      "dependencies": {
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
       }
     },
     "node_modules/cli-highlight": {
@@ -1196,6 +1218,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.18",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.18.tgz",
+      "integrity": "sha512-NS4ZEgNhwbcPz1gfSXCGFnQm0xEiyTSPRthIuWytDzOiEG9xnZ2FbLyfJC4tI2BMAAXpoWbNxHYH75pa3Dq9og=="
     },
     "node_modules/locter": {
       "version": "0.6.2",
@@ -2259,6 +2286,14 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2517,6 +2552,11 @@
         "@types/node": "*"
       }
     },
+    "@types/validator": {
+      "version": "13.7.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
+      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2742,6 +2782,21 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
+      }
+    },
+    "class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "class-validator": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
+      "requires": {
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
       }
     },
     "cli-highlight": {
@@ -3244,6 +3299,11 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "libphonenumber-js": {
+      "version": "1.10.18",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.18.tgz",
+      "integrity": "sha512-NS4ZEgNhwbcPz1gfSXCGFnQm0xEiyTSPRthIuWytDzOiEG9xnZ2FbLyfJC4tI2BMAAXpoWbNxHYH75pa3Dq9og=="
     },
     "locter": {
       "version": "0.6.2",
@@ -3996,6 +4056,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,8 @@
         "morgan": "^1.10.0",
         "mysql2": "^2.3.3",
         "reflect-metadata": "^0.1.13",
-        "typeorm": "^0.3.11"
+        "typeorm": "^0.3.11",
+        "typeorm-extension": "^2.4.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.15",
@@ -38,6 +39,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -720,6 +730,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/ebec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ebec/-/ebec-0.1.0.tgz",
+      "integrity": "sha512-QP7lg0ZqM266C//l53J2ywUPSi+rsZx8/uNxkBMUPL+GpGyeEy0V5opqc1fKS6fcV/vLNnCBe2z2kNxDCQMVqg==",
+      "dependencies": {
+        "smob": "^0.0.6"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1179,6 +1197,52 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/locter": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/locter/-/locter-0.6.2.tgz",
+      "integrity": "sha512-W8B/3PWzyKuCRWM6TOO8V/uoifeWJ88kCyOaZzcBRwaA/j4UBg1mApbDmsFf+hBExasO2kZwyeh5T65yoXC2BQ==",
+      "dependencies": {
+        "ebec": "^0.1.0",
+        "glob": "^8.0.3"
+      }
+    },
+    "node_modules/locter/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/locter/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/locter/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -1607,6 +1671,34 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/rapiq": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/rapiq/-/rapiq-0.6.3.tgz",
+      "integrity": "sha512-8TsSZu4Bhc0QsPh6yCMr5pw3z0SIY1p202bibi23AnnwqNxRiRm7a9sGVQygyaL1ysrVNbr3j3AqkowXMR7Taw==",
+      "dependencies": {
+        "minimatch": "^5.1.2",
+        "smob": "^0.0.6"
+      }
+    },
+    "node_modules/rapiq/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/rapiq/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/raw-body": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
@@ -1787,6 +1879,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw=="
     },
     "node_modules/sqlstring": {
       "version": "2.3.3",
@@ -2061,6 +2158,24 @@
         }
       }
     },
+    "node_modules/typeorm-extension": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/typeorm-extension/-/typeorm-extension-2.4.1.tgz",
+      "integrity": "sha512-dabV2fgy2xzL1p/2dS174F49JsUv2kRbZS3GZO89z3TmdeMUX5OX6Aa7l8ZJfQXhH8AaKuQ2HGbShu58FhZn0w==",
+      "dependencies": {
+        "@faker-js/faker": "^7.6.0",
+        "locter": "^0.6.1",
+        "rapiq": "^0.6.2",
+        "reflect-metadata": "^0.1.13",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "typeorm-extension": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "typeorm": "~0.3.0"
+      }
+    },
     "node_modules/typeorm/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2251,6 +2366,11 @@
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
+    },
+    "@faker-js/faker": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw=="
     },
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
@@ -2781,6 +2901,14 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
+    "ebec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ebec/-/ebec-0.1.0.tgz",
+      "integrity": "sha512-QP7lg0ZqM266C//l53J2ywUPSi+rsZx8/uNxkBMUPL+GpGyeEy0V5opqc1fKS6fcV/vLNnCBe2z2kNxDCQMVqg==",
+      "requires": {
+        "smob": "^0.0.6"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3117,6 +3245,45 @@
         "argparse": "^2.0.1"
       }
     },
+    "locter": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/locter/-/locter-0.6.2.tgz",
+      "integrity": "sha512-W8B/3PWzyKuCRWM6TOO8V/uoifeWJ88kCyOaZzcBRwaA/j4UBg1mApbDmsFf+hBExasO2kZwyeh5T65yoXC2BQ==",
+      "requires": {
+        "ebec": "^0.1.0",
+        "glob": "^8.0.3"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -3449,6 +3616,33 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
+    "rapiq": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/rapiq/-/rapiq-0.6.3.tgz",
+      "integrity": "sha512-8TsSZu4Bhc0QsPh6yCMr5pw3z0SIY1p202bibi23AnnwqNxRiRm7a9sGVQygyaL1ysrVNbr3j3AqkowXMR7Taw==",
+      "requires": {
+        "minimatch": "^5.1.2",
+        "smob": "^0.0.6"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "raw-body": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
@@ -3589,6 +3783,11 @@
           "dev": true
         }
       }
+    },
+    "smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw=="
     },
     "sqlstring": {
       "version": "2.3.3",
@@ -3741,6 +3940,18 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
+      }
+    },
+    "typeorm-extension": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/typeorm-extension/-/typeorm-extension-2.4.1.tgz",
+      "integrity": "sha512-dabV2fgy2xzL1p/2dS174F49JsUv2kRbZS3GZO89z3TmdeMUX5OX6Aa7l8ZJfQXhH8AaKuQ2HGbShu58FhZn0w==",
+      "requires": {
+        "@faker-js/faker": "^7.6.0",
+        "locter": "^0.6.1",
+        "rapiq": "^0.6.2",
+        "reflect-metadata": "^0.1.13",
+        "yargs": "^17.6.2"
       }
     },
     "typescript": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "axios": "^1.2.2",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "dotenv": "^16.0.3",
     "express-session": "^1.17.3",
     "morgan": "^1.10.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "morgan": "^1.10.0",
     "mysql2": "^2.3.3",
     "reflect-metadata": "^0.1.13",
-    "typeorm": "^0.3.11"
+    "typeorm": "^0.3.11",
+    "typeorm-extension": "^2.4.1"
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,6 +3,7 @@ import morgan from 'morgan';
 import dotenv from 'dotenv';
 import { db } from '../ormconfig';
 import userRouter from './routes/user';
+import problemRouter from './routes/problem';
 import session from 'express-session';
 import { runSeeders } from 'typeorm-extension';
 import { PlatformLevel } from './entities/platformLevel.entity';
@@ -46,6 +47,7 @@ app.use(
 );
 
 app.use('/api/users', userRouter);
+app.use('/api/problems', problemRouter);
 
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {
   res.status(err.status || 500);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,19 +4,30 @@ import dotenv from 'dotenv';
 import { db } from '../ormconfig';
 import userRouter from './routes/user';
 import session from 'express-session';
+import { runSeeders } from 'typeorm-extension';
+import { PlatformLevel } from './entities/platformLevel.entity';
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 4000;
 
-db.initialize()
-  .then(() => {
-    console.log('db 연결');
-  })
-  .catch((err) => {
+(async () => {
+  try {
+    await db.initialize();
+    console.log('db연결 성공!');
+
+    // truncate안하고 하면 seed데이터가 새로 실행될 때마다 누적됨
+    // 그래서 platformLevel - problem relation 삭제하고 truncate 진행
+    await db.getRepository(PlatformLevel).clear();
+
+    await runSeeders(db);
+    console.log('seed데이터 생성 성공!');
+  } catch (err) {
+    console.log('db연결실패');
     console.log(err);
-  });
+  }
+})();
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -53,7 +53,7 @@ app.use((err: any, req: Request, res: Response, next: NextFunction) => {
   res.status(err.status || 500);
   res.json({
     isSuccess: false,
-    code: err.status,
+    code: err.status || 500,
     message: err.message,
   });
 });

--- a/backend/src/controllers/problem.controllers.ts
+++ b/backend/src/controllers/problem.controllers.ts
@@ -1,5 +1,24 @@
+import { NextFunction, Request, Response } from 'express';
+import { BadRequestException } from '../error/httpException';
+import ProblemService from '../services/problem.service';
+
 class ProblemController {
-  public async createProblem() {}
+  problemService = new ProblemService();
+
+  public async createProblem(req: Request, res: Response, next: NextFunction) {
+    try {
+      const data = req.body;
+      const { platformName, levelName, id, ...createProblemData } = data;
+
+      const platformLevel = await this.problemService.findPlatformLevel(platformName, levelName);
+      if (platformLevel === null) throw new BadRequestException('플랫폼과 레벨정보가 잘못되었습니다.');
+
+      await this.problemService.createProblem({ ...createProblemData, platformLevelId: platformLevel.id, userId: id });
+      res.status(200).json({ isSuccess: true, code: 200, message: '성공' });
+    } catch (err) {
+      next(err);
+    }
+  }
 }
 
 export default ProblemController;

--- a/backend/src/controllers/problem.controllers.ts
+++ b/backend/src/controllers/problem.controllers.ts
@@ -13,8 +13,29 @@ class ProblemController {
       const platformLevel = await this.problemService.findPlatformLevel(platformName, levelName);
       if (platformLevel === null) throw new BadRequestException('플랫폼과 레벨정보가 잘못되었습니다.');
 
-      await this.problemService.createProblem({ ...createProblemData, platformLevelId: platformLevel.id, userId: id });
+      const userId = await this.problemService.findUserId(id);
+      await this.problemService.createProblem({
+        ...createProblemData,
+        platformLevelId: platformLevel.id,
+        user: userId,
+      });
+
       res.status(200).json({ isSuccess: true, code: 200, message: '성공' });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  public async findAllProblem(req: Request<{}, {}, {}, { user: string }>, res: Response, next: NextFunction) {
+    try {
+      const user = req.query.user;
+      let data;
+      if (user === undefined) {
+        data = await this.problemService.findAllProblem();
+      } else {
+        data = await this.problemService.findAllUserProblem(user);
+      }
+      res.status(200).json({ isSuccess: true, code: 200, message: '성공', data });
     } catch (err) {
       next(err);
     }

--- a/backend/src/controllers/problem.controllers.ts
+++ b/backend/src/controllers/problem.controllers.ts
@@ -40,6 +40,22 @@ class ProblemController {
       next(err);
     }
   }
+
+  public async deleteProblem(req: Request, res: Response, next: NextFunction) {
+    try {
+      const problemId = Number(req.params.problemId);
+      if (Number.isNaN(problemId)) {
+        throw new BadRequestException('문제 id가 숫자가 아닙니다.');
+      }
+
+      const session: any = req.session;
+      await this.problemService.deleteProblem(problemId, session.userGithubId);
+
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  }
 }
 
 export default ProblemController;

--- a/backend/src/controllers/problem.controllers.ts
+++ b/backend/src/controllers/problem.controllers.ts
@@ -1,0 +1,5 @@
+class ProblemController {
+  public async createProblem() {}
+}
+
+export default ProblemController;

--- a/backend/src/entities/platformLevel.entity.ts
+++ b/backend/src/entities/platformLevel.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, Column, PrimaryGeneratedColumn, Unique, ManyToOne, OneToMany } from 'typeorm';
+import { Problem } from './problem.entity';
+
+@Entity()
+export class PlatformLevel {
+  @PrimaryGeneratedColumn()
+  @OneToMany(() => Problem, (problem) => problem.platformLevel)
+  id: number;
+
+  @Column()
+  platformName: string;
+
+  @Column()
+  levelName: string;
+
+  @Column()
+  game: number;
+}

--- a/backend/src/entities/platformLevel.entity.ts
+++ b/backend/src/entities/platformLevel.entity.ts
@@ -4,7 +4,7 @@ import { Problem } from './problem.entity';
 @Entity()
 export class PlatformLevel {
   @PrimaryGeneratedColumn()
-  @OneToMany(() => Problem, (problem) => problem.platformLevel)
+  // @OneToMany(() => Problem, (problem) => problem.platformLevel)
   id: number;
 
   @Column()

--- a/backend/src/entities/problem.entity.ts
+++ b/backend/src/entities/problem.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, Column, PrimaryGeneratedColumn, Unique, ManyToOne, CreateDateColumn } from 'typeorm';
+import { PlatformLevel } from './platformLevel.entity';
+import { User } from './user.entity';
+
+@Entity()
+export class Problem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  image: string;
+
+  @Column()
+  link: string;
+
+  @ManyToOne(() => User, (user) => user.id)
+  user: User;
+
+  @ManyToOne(() => PlatformLevel, (platformLevel) => platformLevel.id)
+  platformLevel: PlatformLevel;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+}

--- a/backend/src/entities/problem.entity.ts
+++ b/backend/src/entities/problem.entity.ts
@@ -16,8 +16,9 @@ export class Problem {
   @ManyToOne(() => User, (user) => user.id)
   user: User;
 
-  @ManyToOne(() => PlatformLevel, (platformLevel) => platformLevel.id)
-  platformLevel: PlatformLevel;
+  // @ManyToOne(() => PlatformLevel, (platformLevel) => platformLevel.id)
+  @Column()
+  platformLevelId: number;
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;

--- a/backend/src/entities/problem.entity.ts
+++ b/backend/src/entities/problem.entity.ts
@@ -1,5 +1,13 @@
-import { Entity, Column, PrimaryGeneratedColumn, Unique, ManyToOne, CreateDateColumn, JoinColumn } from 'typeorm';
-import { PlatformLevel } from './platformLevel.entity';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  Unique,
+  ManyToOne,
+  CreateDateColumn,
+  JoinColumn,
+  DeleteDateColumn,
+} from 'typeorm';
 import { User } from './user.entity';
 
 @Entity()
@@ -23,4 +31,7 @@ export class Problem {
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt?: Date;
 }

--- a/backend/src/entities/problem.entity.ts
+++ b/backend/src/entities/problem.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn, Unique, ManyToOne, CreateDateColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, Unique, ManyToOne, CreateDateColumn, JoinColumn } from 'typeorm';
 import { PlatformLevel } from './platformLevel.entity';
 import { User } from './user.entity';
 
@@ -14,6 +14,7 @@ export class Problem {
   link: string;
 
   @ManyToOne(() => User, (user) => user.id)
+  @JoinColumn({ referencedColumnName: 'userId', name: 'userId' })
   user: User;
 
   // @ManyToOne(() => PlatformLevel, (platformLevel) => platformLevel.id)

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -4,9 +4,9 @@ import { Problem } from './problem.entity';
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
-  @OneToMany(() => Problem, (problem) => problem.user)
   id: number;
 
   @Column({ length: 20, unique: true })
+  @OneToMany(() => Problem, (problem) => problem.user)
   userId: string;
 }

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -1,8 +1,10 @@
-import { Entity, Column, PrimaryGeneratedColumn, Unique } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, Unique, OneToMany } from 'typeorm';
+import { Problem } from './problem.entity';
 
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
+  @OneToMany(() => Problem, (problem) => problem.user)
   id: number;
 
   @Column({ length: 20, unique: true })

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express';
+import { UnAuthorizedException } from '../error/httpException';
+
+class AuthMiddleware {
+  public isLogined(req: Request, res: Response, next: NextFunction) {
+    const session: any = req.session;
+
+    if (session.userId === undefined) throw new UnAuthorizedException('로그인을 해주세요.');
+    else next();
+  }
+
+  public checkRequestUser(req: Request, res: Response, next: NextFunction) {
+    const session: any = req.session;
+    const sessionUser = session.userId;
+    const requestUser = req.body.userId;
+
+    if (sessionUser === requestUser) next();
+    else throw new UnAuthorizedException('권한이 없습니다.');
+  }
+}
+
+export default AuthMiddleware;

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -12,7 +12,7 @@ class AuthMiddleware {
   public checkRequestUser(req: Request, res: Response, next: NextFunction) {
     const session: any = req.session;
     const sessionUser = session.userId;
-    const requestUser = req.body.userId;
+    const requestUser = req.body.id;
 
     if (sessionUser === requestUser) next();
     else throw new UnAuthorizedException('권한이 없습니다.');

--- a/backend/src/middlewares/validateBody.ts
+++ b/backend/src/middlewares/validateBody.ts
@@ -1,0 +1,17 @@
+import { validateOrReject } from 'class-validator';
+import { plainToClass } from 'class-transformer';
+import { Request, Response, NextFunction } from 'express';
+import { BadRequestException } from '../error/httpException';
+
+export function validateBody(schema: { new (): any }) {
+  return async function (req: Request, res: Response, next: NextFunction) {
+    const target = plainToClass(schema, req.body);
+    try {
+      await validateOrReject(target);
+
+      next();
+    } catch (error) {
+      next(new BadRequestException('빈칸이 있거나 필요한 항목이 빠졌습니다.'));
+    }
+  };
+}

--- a/backend/src/models/problem.model.ts
+++ b/backend/src/models/problem.model.ts
@@ -1,0 +1,23 @@
+import { db } from '../../ormconfig';
+import { Problem } from '../entities/problem.entity';
+import { PlatformLevel } from '../entities/platformLevel.entity';
+import { CreateProblem } from '../services/problem.service';
+
+class ProblemModel {
+  problemEntity = db.getRepository(Problem);
+  platformLevelEntity = db.getRepository(PlatformLevel);
+
+  public async findPlatformLevel(platformName: string, levelName: string) {
+    const res = await this.platformLevelEntity.findOneBy({ platformName, levelName });
+    return res;
+  }
+
+  public async createProblem(data: CreateProblem) {
+    console.log(data);
+    // TODO: 왜 userId는 insert가 안 돼..ㅇㅅㅇ
+    const res = this.problemEntity.create(data);
+    await this.problemEntity.save(res);
+  }
+}
+
+export default ProblemModel;

--- a/backend/src/models/problem.model.ts
+++ b/backend/src/models/problem.model.ts
@@ -13,10 +13,39 @@ class ProblemModel {
   }
 
   public async createProblem(data: CreateProblem) {
-    console.log(data);
-    // TODO: 왜 userId는 insert가 안 돼..ㅇㅅㅇ
     const res = this.problemEntity.create(data);
     await this.problemEntity.save(res);
+  }
+
+  public async findAllProblem() {
+    const res = await this.problemEntity
+      .createQueryBuilder('problem')
+      .select('problem.id', 'id')
+      .addSelect('problem.link', 'link')
+      .addSelect('problem.image', 'image')
+      .addSelect('problem.userId', 'userId')
+      .addSelect('problem.createdAt', 'createdAt')
+      .addSelect('platformLevel.platformName', 'platformName')
+      .addSelect('platformLevel.levelName', 'levelName')
+      .leftJoin(PlatformLevel, 'platformLevel', 'platformLevel.id = problem.platformLevelId')
+      .getRawMany();
+    return res;
+  }
+
+  public async findAllUserProblem(userId: string) {
+    const res = await this.problemEntity
+      .createQueryBuilder('problem')
+      .select('problem.id', 'id')
+      .addSelect('problem.link', 'link')
+      .addSelect('problem.image', 'image')
+      .addSelect('problem.userId', 'userId')
+      .addSelect('problem.createdAt', 'createdAt')
+      .addSelect('platformLevel.platformName', 'platformName')
+      .addSelect('platformLevel.levelName', 'levelName')
+      .leftJoin(PlatformLevel, 'platformLevel', 'platformLevel.id = problem.platformLevelId')
+      .where('problem.userId = :userId', { userId })
+      .getRawMany();
+    return res;
   }
 }
 

--- a/backend/src/models/problem.model.ts
+++ b/backend/src/models/problem.model.ts
@@ -47,6 +47,15 @@ class ProblemModel {
       .getRawMany();
     return res;
   }
+
+  public async deleteProblem(problemId: number, userId: string) {
+    await this.problemEntity
+      .createQueryBuilder('problem')
+      .softDelete()
+      .where('id = :id', { id: problemId })
+      .andWhere('userId = :userId', { userId })
+      .execute();
+  }
 }
 
 export default ProblemModel;

--- a/backend/src/models/user.model.ts
+++ b/backend/src/models/user.model.ts
@@ -5,6 +5,7 @@ class UserModel {
   userEntity = db.getRepository(User);
 
   public async findUser(userId: string) {
+    console.log(userId);
     const res = await this.userEntity.findOneBy({ userId });
     return res;
   }
@@ -12,6 +13,11 @@ class UserModel {
   public async createUser(userId: string) {
     const res = this.userEntity.create({ userId });
     await this.userEntity.save(res);
+    return res;
+  }
+
+  public async findUserId(id: number) {
+    const res = await this.userEntity.findOne({ where: { id }, select: { userId: true } });
     return res;
   }
 }

--- a/backend/src/routes/problem.ts
+++ b/backend/src/routes/problem.ts
@@ -1,15 +1,41 @@
 import express from 'express';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import ProblemController from '../controllers/problem.controllers';
 import AuthMiddleware from '../middlewares/auth';
+import { validateBody } from '../middlewares/validateBody';
+import { StringLiteral } from 'typescript';
 
 const router = express.Router();
 const problmesController = new ProblemController();
 const authMiddleware = new AuthMiddleware();
 
+class CreateProblemDTO {
+  @IsString()
+  @IsNotEmpty()
+  link: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  id: number;
+
+  @IsString()
+  @IsNotEmpty()
+  platformName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  levelName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  image: string;
+}
+
 router.post(
   '/',
   authMiddleware.isLogined,
   authMiddleware.checkRequestUser,
+  validateBody(CreateProblemDTO),
   problmesController.createProblem.bind(problmesController)
 );
 

--- a/backend/src/routes/problem.ts
+++ b/backend/src/routes/problem.ts
@@ -39,4 +39,6 @@ router.post(
   problmesController.createProblem.bind(problmesController)
 );
 
+router.get('/', problmesController.findAllProblem.bind(problmesController));
+
 export default router;

--- a/backend/src/routes/problem.ts
+++ b/backend/src/routes/problem.ts
@@ -40,4 +40,6 @@ router.post(
 
 router.get('/', problemsController.findAllProblem.bind(problemsController));
 
+router.delete('/:problemId', authMiddleware.isLogined, problemsController.deleteProblem.bind(problemsController));
+
 export default router;

--- a/backend/src/routes/problem.ts
+++ b/backend/src/routes/problem.ts
@@ -3,10 +3,9 @@ import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import ProblemController from '../controllers/problem.controllers';
 import AuthMiddleware from '../middlewares/auth';
 import { validateBody } from '../middlewares/validateBody';
-import { StringLiteral } from 'typescript';
 
 const router = express.Router();
-const problmesController = new ProblemController();
+const problemsController = new ProblemController();
 const authMiddleware = new AuthMiddleware();
 
 class CreateProblemDTO {
@@ -36,9 +35,9 @@ router.post(
   authMiddleware.isLogined,
   authMiddleware.checkRequestUser,
   validateBody(CreateProblemDTO),
-  problmesController.createProblem.bind(problmesController)
+  problemsController.createProblem.bind(problemsController)
 );
 
-router.get('/', problmesController.findAllProblem.bind(problmesController));
+router.get('/', problemsController.findAllProblem.bind(problemsController));
 
 export default router;

--- a/backend/src/routes/problem.ts
+++ b/backend/src/routes/problem.ts
@@ -1,9 +1,16 @@
 import express from 'express';
 import ProblemController from '../controllers/problem.controllers';
+import AuthMiddleware from '../middlewares/auth';
 
 const router = express.Router();
 const problmesController = new ProblemController();
+const authMiddleware = new AuthMiddleware();
 
-router.post('/problems', problmesController.createProblem.bind(problmesController));
+router.post(
+  '/',
+  authMiddleware.isLogined,
+  authMiddleware.checkRequestUser,
+  problmesController.createProblem.bind(problmesController)
+);
 
 export default router;

--- a/backend/src/routes/problem.ts
+++ b/backend/src/routes/problem.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import ProblemController from '../controllers/problem.controllers';
+
+const router = express.Router();
+const problmesController = new ProblemController();
+
+router.post('/problems', problmesController.createProblem.bind(problmesController));
+
+export default router;

--- a/backend/src/seeds/platformLevel.seeder.ts
+++ b/backend/src/seeds/platformLevel.seeder.ts
@@ -1,0 +1,111 @@
+import { Seeder } from 'typeorm-extension';
+import { DataSource } from 'typeorm';
+import { PlatformLevel } from '../entities/platformLevel.entity';
+
+export default class PlatformLevelSeeder implements Seeder {
+  public async run(dataSource: DataSource): Promise<any> {
+    const repository = dataSource.getRepository(PlatformLevel);
+    await repository.insert([
+      {
+        platformName: '백준',
+        levelName: '브론즈3 이하',
+        game: 0,
+      },
+      {
+        platformName: '백준',
+        levelName: '브론즈2 이상',
+        game: 1,
+      },
+      {
+        platformName: '백준',
+        levelName: '실버',
+        game: 2,
+      },
+      {
+        platformName: '백준',
+        levelName: '골드',
+        game: 3,
+      },
+      {
+        platformName: '백준',
+        levelName: '플레티넘',
+        game: 4,
+      },
+      {
+        platformName: '백준',
+        levelName: '다이아',
+        game: 5,
+      },
+      {
+        platformName: '백준',
+        levelName: '루비',
+        game: -1, // 하루 무제한을 어떻게 표시하지..
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'level0',
+        game: 0,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'level1',
+        game: 1,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'level2',
+        game: 2,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'level3',
+        game: 3,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'level4',
+        game: 4,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'level5',
+        game: 5,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'SQL-level2이하',
+        game: 0,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'SQL-level3',
+        game: 1,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'SQL-level4',
+        game: 2,
+      },
+      {
+        platformName: '프로그래머스',
+        levelName: 'SQL-level5',
+        game: 3,
+      },
+      {
+        platformName: '해커랭크',
+        levelName: 'Easy',
+        game: 1,
+      },
+      {
+        platformName: '해커랭크',
+        levelName: 'Medium',
+        game: 2,
+      },
+      {
+        platformName: '해커랭크',
+        levelName: 'Hard',
+        game: 3,
+      },
+    ]);
+  }
+}

--- a/backend/src/services/problem.service.ts
+++ b/backend/src/services/problem.service.ts
@@ -54,6 +54,14 @@ class ProblemService {
       throw err;
     }
   }
+
+  public async deleteProblem(problemId: number, userId: string) {
+    try {
+      await this.problemModel.deleteProblem(problemId, userId);
+    } catch (err) {
+      throw err;
+    }
+  }
 }
 
 export default ProblemService;

--- a/backend/src/services/problem.service.ts
+++ b/backend/src/services/problem.service.ts
@@ -1,0 +1,31 @@
+import ProblemModel from '../models/problem.model';
+
+export interface CreateProblem {
+  userId: number;
+  link: string;
+  image: string;
+  platformLevelId: number;
+}
+
+class ProblemService {
+  problemModel = new ProblemModel();
+
+  public async findPlatformLevel(platformName: string, levelName: string) {
+    try {
+      const platformLevel = await this.problemModel.findPlatformLevel(platformName, levelName);
+      return platformLevel;
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  public async createProblem(data: CreateProblem) {
+    try {
+      await this.problemModel.createProblem(data);
+    } catch (err) {
+      throw err;
+    }
+  }
+}
+
+export default ProblemService;

--- a/backend/src/services/problem.service.ts
+++ b/backend/src/services/problem.service.ts
@@ -1,7 +1,9 @@
+import { User } from '../entities/user.entity';
 import ProblemModel from '../models/problem.model';
+import UserModel from '../models/user.model';
 
 export interface CreateProblem {
-  userId: number;
+  userId: User;
   link: string;
   image: string;
   platformLevelId: number;
@@ -9,6 +11,7 @@ export interface CreateProblem {
 
 class ProblemService {
   problemModel = new ProblemModel();
+  userModel = new UserModel();
 
   public async findPlatformLevel(platformName: string, levelName: string) {
     try {
@@ -22,6 +25,31 @@ class ProblemService {
   public async createProblem(data: CreateProblem) {
     try {
       await this.problemModel.createProblem(data);
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  public async findAllProblem() {
+    try {
+      return await this.problemModel.findAllProblem();
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  public async findAllUserProblem(userId: string) {
+    try {
+      return await this.problemModel.findAllUserProblem(userId);
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  public async findUserId(id: number) {
+    try {
+      const res = await this.userModel.findUserId(id);
+      return res;
     } catch (err) {
       throw err;
     }

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -53,7 +53,6 @@ class UserService {
   public async createUser(userId: string) {
     try {
       const res = await this.userModel.findUser(userId);
-
       if (res === null) {
         return await this.userModel.createUser(userId);
       }


### PR DESCRIPTION
## 주요 작업사항
- 푼 문제 생성
  - 로그인 한 유저만 생성할 수 있도록 미들웨어 처리
  - 로그인 한 유저와 문제를 만드려는 유저가 같은지 확인하는 미들웨어 처리
  - 플랫폼이나 레벨 정보를 잘못 입력했을 경우 400에러 처리
  - 필요한 항목이 빠지거나 빈칸인 경우 400에러 처리(class-validator, class-transformer로 처리)
  - 위를 모두 통과하면 푼 문제를 생성함
- 푼 문제 목록 가져오기
  - 쿼리로 user가 있을 때는 해당 user의 푼문제 목록을 가져오고
  - user가 없을 때는 전체 푼 문제 목록을 가져온다.
  - 별다른 예외 처리는 하지 않았다.
- 푼 문제 삭제
  - soft delete로 처리함
  - 로그인 된 유저만 삭제할 수 있도록 미들웨어 처리
  - 자신이 생성한 문제만 삭제가능하도록 처리 (쿼리 단에서)
    - 다른 유저가 삭제하려고 했을 때 따로 오류 메시지를 뱉지는 않지만 삭제는 되지 않음
