### PR TITLE
main page의 common tap container 

### DIFF
--- a/frontend/src/components/BasicLayout.tsx
+++ b/frontend/src/components/BasicLayout.tsx
@@ -3,9 +3,10 @@ import styled from 'styled-components';
 import Header from './Header';
 
 const CenteredAlignedMain = styled.main`
-  width: 1200px;
+  width: 100%;
   margin: auto;
   padding: 2rem 0;
+  max-width: 70rem;
 `;
 
 const BasicLayout = () => {

--- a/frontend/src/components/CommonTapContainer/index.tsx
+++ b/frontend/src/components/CommonTapContainer/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 const TapContainer = () => {
-  const [radioSelected, setRadioSelected] = useState<'ranking' | 'problemList' | 'dayList'>();
+  const [radioSelected, setRadioSelected] = useState<'ranking' | 'problemList' | 'dayList'>('ranking');
 
   const handleRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget;

--- a/frontend/src/components/CommonTapContainer/index.tsx
+++ b/frontend/src/components/CommonTapContainer/index.tsx
@@ -14,7 +14,7 @@ const TapContainer = () => {
 
   return (
     <div className="">
-      <div className="text-[#b7b7b7 [&>*]:flex-center flex  justify-around rounded-t-2xl bg-[#565656] text-[#b7b7b7] [&>*]:w-full [&>*]:p-4">
+      <div className="[&>*]:flex-center flex justify-around rounded-t-2xl bg-[#565656] text-[#b7b7b7] [&>*]:w-full [&>*]:p-4">
         <label className={`${radioSelected === 'ranking' && 'bg-white text-black'} rounded-tl-2xl`} htmlFor="ranking">
           랭킹
           <input
@@ -49,7 +49,7 @@ const TapContainer = () => {
           />
         </label>
       </div>
-      <div className="flex-center h-full min-h-[65vh] w-full rounded-b-2xl bg-white">
+      <div className="flex-center min-h-[65vh] w-full rounded-b-2xl bg-white">
         {radioSelected === 'ranking' && <div>랭킹컴포넌트</div>}
         {radioSelected === 'problemList' && <div>푼문제컴포넌트</div>}
         {radioSelected === 'dayList' && <div>회차별컴포넌트</div>}

--- a/frontend/src/components/CommonTapContainer/index.tsx
+++ b/frontend/src/components/CommonTapContainer/index.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+const TapContainer = () => {
+  const [radioSelected, setRadioSelected] = useState<'ranking' | 'problemList' | 'dayList'>();
+
+  const handleRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.currentTarget;
+    if (value === 'ranking' || value === 'problemList' || value === 'dayList') {
+      setRadioSelected(value);
+    } else {
+      throw new Error('잘못된 라디오 값 입니다.');
+    }
+  };
+
+  return (
+    <div className="">
+      <div className="text-[#b7b7b7 [&>*]:flex-center flex  justify-around rounded-t-2xl bg-[#565656] text-[#b7b7b7] [&>*]:w-full [&>*]:p-4">
+        <label className={`${radioSelected === 'ranking' && 'bg-white text-black'} rounded-tl-2xl`} htmlFor="ranking">
+          랭킹
+          <input
+            className="hidden"
+            type="radio"
+            id="ranking"
+            name="category"
+            value="ranking"
+            onChange={handleRadioChange}
+          />
+        </label>
+        <label className={`${radioSelected === 'problemList' && 'bg-white text-black'}`} htmlFor="problemList">
+          푼 문제 목록(전체)
+          <input
+            className="hidden"
+            type="radio"
+            id="problemList"
+            name="category"
+            value="problemList"
+            onChange={handleRadioChange}
+          />
+        </label>
+        <label className={`${radioSelected === 'dayList' && 'bg-white text-black'} rounded-tr-2xl`} htmlFor="dayList">
+          회차별 목록
+          <input
+            className="hidden"
+            type="radio"
+            id="dayList"
+            name="category"
+            value="dayList"
+            onChange={handleRadioChange}
+          />
+        </label>
+      </div>
+      <div className="flex-center h-full min-h-[65vh] w-full rounded-b-2xl bg-white">
+        {radioSelected === 'ranking' && <div>랭킹컴포넌트</div>}
+        {radioSelected === 'problemList' && <div>푼문제컴포넌트</div>}
+        {radioSelected === 'dayList' && <div>회차별컴포넌트</div>}
+      </div>
+    </div>
+  );
+};
+
+export default TapContainer;

--- a/frontend/src/components/CommonTapContainer/index.tsx
+++ b/frontend/src/components/CommonTapContainer/index.tsx
@@ -5,10 +5,14 @@ const TapContainer = () => {
 
   const handleRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget;
-    if (value === 'ranking' || value === 'problemList' || value === 'dayList') {
-      setRadioSelected(value);
-    } else {
-      throw new Error('잘못된 라디오 값 입니다.');
+    switch (value) {
+      case 'ranking':
+      case 'problemList':
+      case 'dayList':
+        setRadioSelected(value);
+        break;
+      default:
+        throw new Error('잘못된 라디오 값 입니다.');
     }
   };
 
@@ -24,6 +28,7 @@ const TapContainer = () => {
             name="category"
             value="ranking"
             onChange={handleRadioChange}
+            defaultChecked
           />
         </label>
         <label className={`${radioSelected === 'problemList' && 'bg-white text-black'}`} htmlFor="problemList">

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -3,11 +3,11 @@ import Login from './login';
 
 const Header = () => {
   return (
-    <header className="flex-center h-40 flex-col  gap-2 bg-header-img bg-cover px-8">
+    <header className="flex-center h-40 flex-col  gap-2 bg-header-img bg-cover">
       <a href="/" className="font-title text-7xl text-title">
         TeJinSa
       </a>
-      <div className="flex h-12 w-2/3 items-center justify-between rounded-lg bg-gray-50 bg-opacity-40 shadow-md">
+      <div className="flex h-12 w-full max-w-[70rem] items-center justify-between rounded-lg bg-gray-50 bg-opacity-40 shadow-md">
         <Notice message="추가예정" />
         <Login />
       </div>

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -2,7 +2,7 @@ import TapContainer from '../components/CommonTapContainer';
 
 const Main = () => {
   return (
-    <div>
+    <div className="m-auto">
       <TapContainer />
     </div>
   );

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,4 +1,10 @@
+import TapContainer from '../components/CommonTapContainer';
+
 const Main = () => {
-  return <div>main</div>;
+  return (
+    <div>
+      <TapContainer />
+    </div>
+  );
 };
 export default Main;

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -2,7 +2,7 @@ import TapContainer from '../components/CommonTapContainer';
 
 const Main = () => {
   return (
-    <div className="m-auto">
+    <div>
       <TapContainer />
     </div>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -15,6 +15,9 @@ module.exports = {
       backgroundColor: {
         overlay: 'rgba(0,0,0,0.4)',
       },
+      borderWidth: {
+        '1': '1px',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
<!-- 이 PR에서 구현한 작업들을 나열 -->

## 주요 작업사항

- main page에 사용되는 common tap container 구현
- 반응형 적용
  - 기존 1200px고정이던 화면구성에서 1200px(정확히는 70rem = 1120px)는 max-width로 유지하고 작은화면에 대한 반응형을 추가해줌.

<!-- (선택) 작업사항을 파악하기 쉽게 스크린샷 첨부 -->

## 스크린샷

![화면_기록_2023-01-21_오후_5_33_32_AdobeExpress](https://user-images.githubusercontent.com/92029332/213859074-3d702098-5f18-4731-a5f0-79cf3eaae771.gif)



<!-- (선택) 리뷰요청사항 및 기타 하고싶은말 -->

## 팀원분들께

- ⭐️ 디자인 피드백 대환영 ⭐️
- 새해 복 많이 받으세요~~~
